### PR TITLE
feat: improve keyboard navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "akar-icons",
-  "version": "1.0.3",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7344,6 +7344,11 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
+    },
+    "tinykeys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinykeys/-/tinykeys-1.1.1.tgz",
+      "integrity": "sha512-YEA1TGMlkMabXI0NGddRFti+c1eMO2QP7wefwibSz0Pip8sA+d99yX5Pp7pK7wUeTKmrF4ys4XZVz44YydlTYg=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "styled-components": "^5.1.1",
-    "styled-system": "^5.1.5"
+    "styled-system": "^5.1.5",
+    "tinykeys": "^1.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import IconWrapper from './components/IconWrapper';
 import AlertBox from './components/AlertBox';
 import Footer from './components/Footer';
 import CustomizationBar from './components/CustomizationBar';
+import SearchResults from './components/SearchResults';
 import theme from './theme';
 
 import upperCamelCase from 'uppercamelcase';
@@ -14,23 +15,12 @@ import data from './data.json';
 
 const Container = styled.div`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
   grid-gap: 8px;
-  justify-items: stretch;
-  align-items: stretch;
   margin: 0;
   padding: 16px;
-  list-style: none;
   @media (min-width: 768px) {
-    grid-template-columns: repeat(4, 1fr);
     grid-gap: 12px;
     padding: 12px 24px 24px;
-  }
-  @media (min-width: 1152px) {
-    grid-template-columns: repeat(8, 1fr);
-  }
-  @media (min-width: 2560px) {
-    grid-template-columns: repeat(12, 1fr);
   }
 `
 
@@ -126,8 +116,8 @@ const App = () => {
   const [height, setHeight] = useState(0);
   const [badge, setBadge] = useState(true);
 
-  const results = fuse.search(query);
-  const searchResults = query ? results.map(search => upperCamelCase(search.item.name)) : ICON_KEYS;
+  const fuseResults = fuse.search(query);
+  const results = query ? fuseResults.map(search => upperCamelCase(search.item.name)) : ICON_KEYS;
 
   return (
     <>
@@ -147,24 +137,26 @@ const App = () => {
             size={size}
             setSize={setSize}
           />
-          {
-            searchResults.length > 0 ?
-              searchResults.map((key, index) => {
-                const Icon = icons[key];
-                return (
-                  <IconWrapper key={index} icon={key} setOpen={setOpen} setName={setName}>
-                    <IconContainer>
-                      <Icon strokeWidth={stroke} size={size} />
-                    </IconContainer>
-                  </IconWrapper>
-                )
-              }) :
+          <SearchResults>
+            {results.length === 0 && (
               <NoResults>
                 <span style={{ fontSize: "6em", color: "#DAE4E8" }}>( · _ · )</span>
                 <span style={{ margin: "2em 0 1em 0" }}>There are no icons for <code>{query}</code></span>
                 <SecondaryLinks href="https://github.com/artcoholic/akar-icons/issues" target="_blank"><icons.File size={14} />Request an icon</SecondaryLinks>
               </NoResults>
-          }
+            )}
+            {results.map((key, index) => {
+              const Icon = icons[key];
+
+              return (
+                <IconWrapper key={index} icon={key} setOpen={setOpen} setName={setName}>
+                  <IconContainer>
+                    <Icon strokeWidth={stroke} size={size} />
+                  </IconContainer>
+                </IconWrapper>
+              )
+            })}
+          </SearchResults>
         </Container>
         {open && <AlertBox open={open} setOpen={setOpen} name={name} icons={icons} />}
         <Footer icons={icons} />

--- a/src/components/CustomizationBar.js
+++ b/src/components/CustomizationBar.js
@@ -35,19 +35,18 @@ const Wrapper = styled.div`
 `
 
 const ResetButton = styled.button`
-  cursor: pointer;
-  pointer-events: ${({ reset }) => reset ? 'auto' : 'none'};
   border: none;
   outline: none;
   font-size: 12px;
   transition: all 150ms ease-out;
   border-radius: 4px;
-  color: ${({ reset }) => reset ? '#1B1C32' : '#BDBDBD'};
-  background: ${({ reset }) => reset ? '#FFD542' : '#EFEFEF'};
+  background: ${({ disabled }) => disabled ? '#EFEFEF' : '#FFD542'};
+  color: ${({ disabled }) => disabled ? '#BDBDBD' : '#1B1C32'};
+  cursor: ${({ disabled }) => disabled ? 'not-allowed' : 'pointer'};
   order: -1;
   padding: 0 16px;
   margin-left: 8px;
-  &:hover {
+  &:enabled:hover {
     background-color: #e8c031;
   }
   @media (min-width: 768px) {
@@ -58,15 +57,11 @@ const ResetButton = styled.button`
 
 export default ({ stroke, setStroke, size, setSize, query, updateQuery, icons, height }) => {
   const [isStuck, setIsStuck] = useState(false);
-  const [reset, setReset] = useState(false);
+  const isEnabled = query !== '' || stroke != 2 || size != 24;
 
   useScrollPosition(({ currPos }) => {
     setIsStuck(currPos.y < -height);
   })
-
-  useEffect(() => {
-    setReset(query !== '' || stroke != 2 || size != 24);
-  }, [stroke, query, size]);
 
   function handleReset() {
     setStroke(2);
@@ -100,7 +95,7 @@ export default ({ stroke, setStroke, size, setSize, query, updateQuery, icons, h
             type="icon-size"
           />
         </Wrapper>
-        <ResetButton reset={reset} isStuck={isStuck} type="button" onClick={handleReset} aria-label="Reset">
+        <ResetButton disabled={!isEnabled} type="button" onClick={handleReset} aria-label="Reset">
           <icons.ArrowCounterClockwise size={16} />
         </ResetButton>
       </Container>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -62,16 +62,6 @@ const Wrapper = styled.div`
 `
 
 const ButtonLink = styled.a`
-  display: flex;
-  align-items: center;
-  color: #1B1C32;
-  width: 100%;
-  @media (min-width: 768px) {
-    width: auto;
-  }
-`
-
-const Button = styled.button`
   -webkit-appearance: none;
   border: 0;
   padding: 15px 1.2em;
@@ -80,6 +70,7 @@ const Button = styled.button`
   color: #CDCDD8;
   border-radius: 4px;
   display: flex;
+  align-items: center;
   align-content: center;
   cursor: pointer;
   margin: 12px 0 0 0;
@@ -103,7 +94,9 @@ const Button = styled.button`
   }
   @media (min-width: 768px) {
     margin: 0 12px;
+    width: auto;
   }
+
 `
 
 const Logo = styled.div`
@@ -172,7 +165,7 @@ export default ({ icons, setHeight }) => {
           justifyContent="center"
         >
           <ButtonLink href="https://github.com/artcoholic/akar-icons#readme" target="_blank" rel="noopener">
-            <Button>Get started <icons.ArrowUpRight size={16} /></Button>
+            Get started <icons.ArrowUpRight size={16} />
           </ButtonLink>
         </Wrapper>
       </InnerContainer>

--- a/src/components/IconWrapper.js
+++ b/src/components/IconWrapper.js
@@ -15,7 +15,7 @@ const IconWrapper = styled.button`
   position: relative;
   color: #1B1C32;
   -webkit-appearance: none;
-  &:hover {
+  &:hover, &:focus {
     background: #dae4e8;
     span {
       opacity: 1;
@@ -25,7 +25,6 @@ const IconWrapper = styled.button`
   &:focus, &:active {
     outline: none;
     box-shadow: 0 0 0 2px #1B1C32;
-    background: white;
   }
   span {
     position: absolute;

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -88,6 +88,11 @@ export default ({ query, updateQuery, icons }) => {
     });
   };
 
+  function onClear() {
+    searchInput.current.focus();
+    updateQuery('');
+  }
+
   function autoFocus(e) {
     if (e.key === '/') {
       searchInput.current.focus();
@@ -112,7 +117,11 @@ export default ({ query, updateQuery, icons }) => {
         onBlur={() => setFocus(false)}
         aria-label="Search"
       />
-      {query && <ClearButton onClick={() => updateQuery('')}><icons.Cross size={14} strokeWidth={3} /></ClearButton>}
+      {query && (
+        <ClearButton aria-label="Clear search" onClick={onClear}>
+          <icons.Cross size={14} strokeWidth={3} />
+        </ClearButton>
+      )}
       {!query && !focus && <ForwardSlash>/</ForwardSlash>}
     </Container>
   )

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import tinykeys from 'tinykeys';
+
+const Container = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-gap: 8px;
+  justify-items: stretch;
+  align-items: stretch;
+  list-style: none;
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(4, 1fr);
+    grid-gap: 12px;
+  }
+  @media (min-width: 1152px) {
+    grid-template-columns: repeat(8, 1fr);
+  }
+  @media (min-width: 2560px) {
+    grid-template-columns: repeat(12, 1fr);
+  }
+`;
+
+const getColumns = parentEl => {
+  if (!parentEl) {
+    return;
+  }
+
+  const { gridTemplateColumns } = window.getComputedStyle(parentEl);
+
+  return gridTemplateColumns.split(' ').length;
+};
+
+const moveFocus = (parentEl, nextPosition) => {
+  if (!parentEl || !nextPosition) {
+    return;
+  }
+
+  const activeEl = document.activeElement;
+  const buttons = Array.from(parentEl.querySelectorAll('button'));
+
+  buttons.some((btn, i) => {
+    const newNodeKey = i + nextPosition;
+
+    if (btn !== activeEl) {
+      return false;
+    }
+
+    if (newNodeKey <= buttons.length - 1 && newNodeKey >= 0) {
+      buttons[newNodeKey].focus();
+      return true;
+    }
+
+    buttons[0].focus();
+
+    return true;
+  });
+};
+
+export default props => {
+  const ref = useRef();
+
+  useEffect(() => {
+    const unsubscribe = tinykeys(window, {
+      ArrowDown: () => moveFocus(ref.current, getColumns(ref.current)),
+      ArrowLeft: () => moveFocus(ref.current, -1),
+      ArrowRight: () => moveFocus(ref.current, 1),
+      ArrowUp: () => moveFocus(ref.current, getColumns(ref.current) * -1)
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  return <Container {...props} ref={ref} />;
+};


### PR DESCRIPTION
Hi again! 👋🏽 

This PR proposes some improvements related to keyboard navigation:

- `Get started` has two focusable elements but we can use only the anchor tag
- The reset button is focusable even when "disabled" <- it's a visual change only
- It's not possible to navigate with arrow keys inside the icon list
- The input loses focus after the clear button is pressed

Let me know your thoughts on these changes - I hope you like them 😄 