### PR TITLE
Add tree-shakeable ESM package build

### DIFF
--- a/bin/template.js
+++ b/bin/template.js
@@ -22,7 +22,6 @@ const getAttrs = (style) => {
 
 const getElementCode = (ComponentName, attrs, svgCode) => `
   import React from 'react';
-  import PropTypes from 'prop-types';
 
   const ${ComponentName} = ({ color = 'currentColor', size = '24', ...otherProps }) => {
     return (
@@ -32,12 +31,16 @@ const getElementCode = (ComponentName, attrs, svgCode) => `
     )
   };
 
-  ${ComponentName}.propTypes = {
-    color: PropTypes.string,
-    size: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
+  if (process.env.NODE_ENV !== 'production') {
+    const PropTypes = require('prop-types');
+
+    ${ComponentName}.propTypes = {
+      color: PropTypes.string,
+      size: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+      ]),
+    }
   }
 
   export default ${ComponentName}

--- a/build/rollup.config.bundle.js
+++ b/build/rollup.config.bundle.js
@@ -6,21 +6,44 @@ const resolveFile = function (filePath) {
   return path.join(__dirname, '..', filePath)
 }
 
-export default {
-  input: 'src/icons.js',
+const babelOptions = {
+  exclude: 'node_modules/**',
+  babelHelpers: 'bundled',
+  presets: [
+    ['@babel/preset-env', { modules: false }],
+    '@babel/preset-react',
+  ],
+};
+
+const external = ['react', 'prop-types'];
+const input = 'src/icons.js';
+
+export default [{
+  input,
   output: {
-    file: 'dist/index.js',
-    format: 'cjs',
+    dir: 'dist/esm',
+    format: 'esm',
+    preserveModules: true,
+    preserveModulesRoot: 'src',
   },
-  external: ['react', 'prop-types'],
+  external,
   plugins: [
     copy({
       targets: [
         { src: resolveFile('src/icons.d.ts'), dest: resolveFile('dist/') }
       ]
     }),
-    babel({
-      exclude: 'node_modules/**',
-    }),
+    babel(babelOptions),
   ],
-};
+}, {
+  input: 'src/icons.js',
+  output: {
+    file: 'dist/index.js',
+    format: 'cjs',
+    exports: 'named',
+  },
+  external,
+  plugins: [
+    babel(babelOptions),
+  ],
+}];

--- a/build/rollup.config.bundle.js
+++ b/build/rollup.config.bundle.js
@@ -1,6 +1,7 @@
 import babel from '@rollup/plugin-babel';
 import path from 'path';
 import copy from 'rollup-plugin-copy';
+import replace from '@rollup/plugin-replace';
 
 const resolveFile = function (filePath) {
   return path.join(__dirname, '..', filePath)
@@ -33,6 +34,10 @@ export default [{
         { src: resolveFile('src/icons.d.ts'), dest: resolveFile('dist/') }
       ]
     }),
+    replace({
+      preventAssignment: true,
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
     babel(babelOptions),
   ],
 }, {
@@ -44,6 +49,10 @@ export default [{
   },
   external,
   plugins: [
+    replace({
+      preventAssignment: true,
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
     babel(babelOptions),
   ],
 }];

--- a/build/rollup.config.bundle.js
+++ b/build/rollup.config.bundle.js
@@ -7,7 +7,17 @@ const resolveFile = function (filePath) {
   return path.join(__dirname, '..', filePath)
 }
 
-const babelOptions = {
+const esmBabelOptions = {
+  exclude: 'node_modules/**',
+  babelrc: false,
+  configFile: false,
+  babelHelpers: 'bundled',
+  presets: [
+    ['@babel/preset-react', { useSpread: true }],
+  ],
+};
+
+const cjsBabelOptions = {
   exclude: 'node_modules/**',
   babelHelpers: 'bundled',
   presets: [
@@ -38,7 +48,7 @@ export default [{
       preventAssignment: true,
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    babel(babelOptions),
+    babel(esmBabelOptions),
   ],
 }, {
   input: 'src/icons.js',
@@ -53,6 +63,6 @@ export default [{
       preventAssignment: true,
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    babel(babelOptions),
+    babel(cjsBabelOptions),
   ],
 }];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.9.31",
   "description": "A perfectly rounded icon library made for everyone.",
   "main": "dist/index.js",
+  "module": "dist/esm/icons.js",
   "typings": "dist/icons.d.ts",
+  "sideEffects": false,
   "files": [
     "dist"
   ],
@@ -30,7 +32,7 @@
   "scripts": {
     "fetch": "node bin/fetchSVG.js",
     "generate": "sudo rm -rf src/icons && node bin/build.js",
-    "build:bundle": "sudo rm -rf dist && node_modules/.bin/rollup --c ./build/rollup.config.bundle.js",
+    "build:bundle": "rm -rf dist && node_modules/.bin/rollup --c ./build/rollup.config.bundle.js",
     "dev": "rollup -w -c ./build/rollup.config.dev.js",
     "build": "rollup -c ./build/rollup.config.prod.js"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fetch": "node bin/fetchSVG.js",
     "generate": "sudo rm -rf src/icons && node bin/build.js",
     "build:bundle": "rm -rf dist && node_modules/.bin/rollup --c ./build/rollup.config.bundle.js",
+    "prepare": "npm run build:bundle",
     "dev": "rollup -w -c ./build/rollup.config.dev.js",
     "build": "rollup -c ./build/rollup.config.prod.js"
   },

--- a/src/icons/air.js
+++ b/src/icons/air.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Air = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Air = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Air.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Air.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Air;

--- a/src/icons/airplay-audio.js
+++ b/src/icons/airplay-audio.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AirplayAudio = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const AirplayAudio = ({
   );
 };
 
-AirplayAudio.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AirplayAudio.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AirplayAudio;

--- a/src/icons/airplay-video.js
+++ b/src/icons/airplay-video.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AirplayVideo = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const AirplayVideo = ({
   );
 };
 
-AirplayVideo.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AirplayVideo.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AirplayVideo;

--- a/src/icons/airpods.js
+++ b/src/icons/airpods.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Airpods = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -27,9 +26,13 @@ const Airpods = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Airpods.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Airpods.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Airpods;

--- a/src/icons/alarm.js
+++ b/src/icons/alarm.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Alarm = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -26,9 +25,13 @@ const Alarm = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Alarm.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Alarm.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Alarm;

--- a/src/icons/align-bottom.js
+++ b/src/icons/align-bottom.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignBottom = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const AlignBottom = ({
   );
 };
 
-AlignBottom.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignBottom.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignBottom;

--- a/src/icons/align-horizontal-center.js
+++ b/src/icons/align-horizontal-center.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignHorizontalCenter = ({
   color = 'currentColor',
@@ -28,9 +27,13 @@ const AlignHorizontalCenter = ({
   );
 };
 
-AlignHorizontalCenter.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignHorizontalCenter.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignHorizontalCenter;

--- a/src/icons/align-left.js
+++ b/src/icons/align-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignLeft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const AlignLeft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-AlignLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignLeft;

--- a/src/icons/align-right.js
+++ b/src/icons/align-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignRight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const AlignRight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-AlignRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignRight;

--- a/src/icons/align-to-bottom.js
+++ b/src/icons/align-to-bottom.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignToBottom = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const AlignToBottom = ({
   );
 };
 
-AlignToBottom.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignToBottom.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignToBottom;

--- a/src/icons/align-to-middle.js
+++ b/src/icons/align-to-middle.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignToMiddle = ({
   color = 'currentColor',
@@ -28,9 +27,13 @@ const AlignToMiddle = ({
   );
 };
 
-AlignToMiddle.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignToMiddle.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignToMiddle;

--- a/src/icons/align-to-top.js
+++ b/src/icons/align-to-top.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignToTop = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const AlignToTop = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-AlignToTop.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignToTop.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignToTop;

--- a/src/icons/align-top.js
+++ b/src/icons/align-top.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignTop = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const AlignTop = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-AlignTop.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignTop.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignTop;

--- a/src/icons/align-vertical-center.js
+++ b/src/icons/align-vertical-center.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AlignVerticalCenter = ({
   color = 'currentColor',
@@ -28,9 +27,13 @@ const AlignVerticalCenter = ({
   );
 };
 
-AlignVerticalCenter.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AlignVerticalCenter.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AlignVerticalCenter;

--- a/src/icons/android-fill.js
+++ b/src/icons/android-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AndroidFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const AndroidFill = ({
   );
 };
 
-AndroidFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AndroidFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AndroidFill;

--- a/src/icons/angular-fill.js
+++ b/src/icons/angular-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AngularFill = ({
   color = 'currentColor',
@@ -21,9 +20,13 @@ const AngularFill = ({
   );
 };
 
-AngularFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AngularFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AngularFill;

--- a/src/icons/arrow-back-thick-fill.js
+++ b/src/icons/arrow-back-thick-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowBackThickFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ArrowBackThickFill = ({
   );
 };
 
-ArrowBackThickFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowBackThickFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowBackThickFill;

--- a/src/icons/arrow-back-thick.js
+++ b/src/icons/arrow-back-thick.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowBackThick = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ArrowBackThick = ({
   );
 };
 
-ArrowBackThick.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowBackThick.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowBackThick;

--- a/src/icons/arrow-back.js
+++ b/src/icons/arrow-back.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowBack = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ArrowBack = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ArrowBack.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowBack.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowBack;

--- a/src/icons/arrow-clockwise.js
+++ b/src/icons/arrow-clockwise.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowClockwise = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowClockwise = ({
   );
 };
 
-ArrowClockwise.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowClockwise.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowClockwise;

--- a/src/icons/arrow-counter-clockwise.js
+++ b/src/icons/arrow-counter-clockwise.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowCounterClockwise = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowCounterClockwise = ({
   );
 };
 
-ArrowCounterClockwise.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowCounterClockwise.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowCounterClockwise;

--- a/src/icons/arrow-cycle.js
+++ b/src/icons/arrow-cycle.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowCycle = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const ArrowCycle = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ArrowCycle.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowCycle.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowCycle;

--- a/src/icons/arrow-down-left.js
+++ b/src/icons/arrow-down-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowDownLeft = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowDownLeft = ({
   );
 };
 
-ArrowDownLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowDownLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowDownLeft;

--- a/src/icons/arrow-down-right.js
+++ b/src/icons/arrow-down-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowDownRight = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowDownRight = ({
   );
 };
 
-ArrowDownRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowDownRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowDownRight;

--- a/src/icons/arrow-down-thick.js
+++ b/src/icons/arrow-down-thick.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowDownThick = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ArrowDownThick = ({
   );
 };
 
-ArrowDownThick.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowDownThick.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowDownThick;

--- a/src/icons/arrow-down.js
+++ b/src/icons/arrow-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowDown = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ArrowDown = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ArrowDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowDown;

--- a/src/icons/arrow-forward-thick-fill.js
+++ b/src/icons/arrow-forward-thick-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowForwardThickFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ArrowForwardThickFill = ({
   );
 };
 
-ArrowForwardThickFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowForwardThickFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowForwardThickFill;

--- a/src/icons/arrow-forward-thick.js
+++ b/src/icons/arrow-forward-thick.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowForwardThick = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ArrowForwardThick = ({
   );
 };
 
-ArrowForwardThick.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowForwardThick.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowForwardThick;

--- a/src/icons/arrow-forward.js
+++ b/src/icons/arrow-forward.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowForward = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowForward = ({
   );
 };
 
-ArrowForward.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowForward.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowForward;

--- a/src/icons/arrow-left-thick.js
+++ b/src/icons/arrow-left-thick.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowLeftThick = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ArrowLeftThick = ({
   );
 };
 
-ArrowLeftThick.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowLeftThick.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowLeftThick;

--- a/src/icons/arrow-left.js
+++ b/src/icons/arrow-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowLeft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ArrowLeft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ArrowLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowLeft;

--- a/src/icons/arrow-repeat.js
+++ b/src/icons/arrow-repeat.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowRepeat = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const ArrowRepeat = ({
   );
 };
 
-ArrowRepeat.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowRepeat.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowRepeat;

--- a/src/icons/arrow-right-left.js
+++ b/src/icons/arrow-right-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowRightLeft = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowRightLeft = ({
   );
 };
 
-ArrowRightLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowRightLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowRightLeft;

--- a/src/icons/arrow-right-thick.js
+++ b/src/icons/arrow-right-thick.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowRightThick = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ArrowRightThick = ({
   );
 };
 
-ArrowRightThick.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowRightThick.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowRightThick;

--- a/src/icons/arrow-right.js
+++ b/src/icons/arrow-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowRight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ArrowRight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ArrowRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowRight;

--- a/src/icons/arrow-shuffle.js
+++ b/src/icons/arrow-shuffle.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowShuffle = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const ArrowShuffle = ({
   );
 };
 
-ArrowShuffle.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowShuffle.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowShuffle;

--- a/src/icons/arrow-up-down.js
+++ b/src/icons/arrow-up-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowUpDown = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowUpDown = ({
   );
 };
 
-ArrowUpDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowUpDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowUpDown;

--- a/src/icons/arrow-up-left.js
+++ b/src/icons/arrow-up-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowUpLeft = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowUpLeft = ({
   );
 };
 
-ArrowUpLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowUpLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowUpLeft;

--- a/src/icons/arrow-up-right.js
+++ b/src/icons/arrow-up-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowUpRight = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ArrowUpRight = ({
   );
 };
 
-ArrowUpRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowUpRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowUpRight;

--- a/src/icons/arrow-up-thick.js
+++ b/src/icons/arrow-up-thick.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowUpThick = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ArrowUpThick = ({
   );
 };
 
-ArrowUpThick.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowUpThick.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowUpThick;

--- a/src/icons/arrow-up.js
+++ b/src/icons/arrow-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ArrowUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ArrowUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ArrowUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ArrowUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ArrowUp;

--- a/src/icons/ascending.js
+++ b/src/icons/ascending.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Ascending = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Ascending = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Ascending.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Ascending.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Ascending;

--- a/src/icons/attach.js
+++ b/src/icons/attach.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Attach = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Attach = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Attach.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Attach.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Attach;

--- a/src/icons/augmented-reality.js
+++ b/src/icons/augmented-reality.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const AugmentedReality = ({
   color = 'currentColor',
@@ -29,9 +28,13 @@ const AugmentedReality = ({
   );
 };
 
-AugmentedReality.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  AugmentedReality.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default AugmentedReality;

--- a/src/icons/backspace-fill.js
+++ b/src/icons/backspace-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BackspaceFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const BackspaceFill = ({
   );
 };
 
-BackspaceFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BackspaceFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BackspaceFill;

--- a/src/icons/backspace.js
+++ b/src/icons/backspace.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Backspace = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Backspace = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Backspace.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Backspace.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Backspace;

--- a/src/icons/bank.js
+++ b/src/icons/bank.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Bank = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Bank = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Bank.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Bank.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Bank;

--- a/src/icons/basket.js
+++ b/src/icons/basket.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Basket = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Basket = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Basket.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Basket.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Basket;

--- a/src/icons/battery-charging.js
+++ b/src/icons/battery-charging.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BatteryCharging = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const BatteryCharging = ({
   );
 };
 
-BatteryCharging.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BatteryCharging.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BatteryCharging;

--- a/src/icons/battery-empty.js
+++ b/src/icons/battery-empty.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BatteryEmpty = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const BatteryEmpty = ({
   );
 };
 
-BatteryEmpty.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BatteryEmpty.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BatteryEmpty;

--- a/src/icons/battery-full.js
+++ b/src/icons/battery-full.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BatteryFull = ({
   color = 'currentColor',
@@ -28,9 +27,13 @@ const BatteryFull = ({
   );
 };
 
-BatteryFull.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BatteryFull.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BatteryFull;

--- a/src/icons/battery-low.js
+++ b/src/icons/battery-low.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BatteryLow = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const BatteryLow = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-BatteryLow.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BatteryLow.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BatteryLow;

--- a/src/icons/battery-medium.js
+++ b/src/icons/battery-medium.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BatteryMedium = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const BatteryMedium = ({
   );
 };
 
-BatteryMedium.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BatteryMedium.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BatteryMedium;

--- a/src/icons/behance-fill.js
+++ b/src/icons/behance-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BehanceFill = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const BehanceFill = ({
   );
 };
 
-BehanceFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BehanceFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BehanceFill;

--- a/src/icons/bell.js
+++ b/src/icons/bell.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Bell = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Bell = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Bell.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Bell.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Bell;

--- a/src/icons/bicycle.js
+++ b/src/icons/bicycle.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Bicycle = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -25,9 +24,13 @@ const Bicycle = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Bicycle.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Bicycle.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Bicycle;

--- a/src/icons/bitcoin-fill.js
+++ b/src/icons/bitcoin-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BitcoinFill = ({
   color = 'currentColor',
@@ -33,9 +32,13 @@ const BitcoinFill = ({
   );
 };
 
-BitcoinFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BitcoinFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BitcoinFill;

--- a/src/icons/block.js
+++ b/src/icons/block.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Block = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Block = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Block.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Block.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Block;

--- a/src/icons/bluetooth.js
+++ b/src/icons/bluetooth.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Bluetooth = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Bluetooth = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Bluetooth.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Bluetooth.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Bluetooth;

--- a/src/icons/boat.js
+++ b/src/icons/boat.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Boat = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Boat = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Boat.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Boat.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Boat;

--- a/src/icons/book-close.js
+++ b/src/icons/book-close.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BookClose = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const BookClose = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-BookClose.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BookClose.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BookClose;

--- a/src/icons/book-open.js
+++ b/src/icons/book-open.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BookOpen = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const BookOpen = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-BookOpen.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BookOpen.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BookOpen;

--- a/src/icons/bootstrap-fill.js
+++ b/src/icons/bootstrap-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const BootstrapFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const BootstrapFill = ({
   );
 };
 
-BootstrapFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  BootstrapFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default BootstrapFill;

--- a/src/icons/box.js
+++ b/src/icons/box.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Box = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Box = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Box.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Box.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Box;

--- a/src/icons/briefcase.js
+++ b/src/icons/briefcase.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Briefcase = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Briefcase = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Briefcase.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Briefcase.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Briefcase;

--- a/src/icons/bug.js
+++ b/src/icons/bug.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Bug = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -28,9 +27,13 @@ const Bug = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Bug.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Bug.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Bug;

--- a/src/icons/cake.js
+++ b/src/icons/cake.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Cake = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Cake = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Cake.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Cake.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Cake;

--- a/src/icons/calculator.js
+++ b/src/icons/calculator.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Calculator = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Calculator = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Calculator.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Calculator.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Calculator;

--- a/src/icons/calendar.js
+++ b/src/icons/calendar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Calendar = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Calendar = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Calendar.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Calendar.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Calendar;

--- a/src/icons/camera.js
+++ b/src/icons/camera.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Camera = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Camera = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Camera.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Camera.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Camera;

--- a/src/icons/cart.js
+++ b/src/icons/cart.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Cart = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Cart = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Cart.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Cart.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Cart;

--- a/src/icons/chat-add.js
+++ b/src/icons/chat-add.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChatAdd = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const ChatAdd = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ChatAdd.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChatAdd.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChatAdd;

--- a/src/icons/chat-approve.js
+++ b/src/icons/chat-approve.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChatApprove = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const ChatApprove = ({
   );
 };
 
-ChatApprove.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChatApprove.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChatApprove;

--- a/src/icons/chat-bubble.js
+++ b/src/icons/chat-bubble.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChatBubble = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ChatBubble = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ChatBubble.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChatBubble.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChatBubble;

--- a/src/icons/chat-dots.js
+++ b/src/icons/chat-dots.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChatDots = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const ChatDots = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ChatDots.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChatDots.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChatDots;

--- a/src/icons/chat-edit.js
+++ b/src/icons/chat-edit.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChatEdit = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const ChatEdit = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ChatEdit.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChatEdit.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChatEdit;

--- a/src/icons/chat-error.js
+++ b/src/icons/chat-error.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChatError = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const ChatError = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ChatError.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChatError.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChatError;

--- a/src/icons/chat-question.js
+++ b/src/icons/chat-question.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChatQuestion = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const ChatQuestion = ({
   );
 };
 
-ChatQuestion.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChatQuestion.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChatQuestion;

--- a/src/icons/chat-remove.js
+++ b/src/icons/chat-remove.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChatRemove = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const ChatRemove = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ChatRemove.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChatRemove.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChatRemove;

--- a/src/icons/check-box-fill.js
+++ b/src/icons/check-box-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CheckBoxFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CheckBoxFill = ({
   );
 };
 
-CheckBoxFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CheckBoxFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CheckBoxFill;

--- a/src/icons/check-box.js
+++ b/src/icons/check-box.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CheckBox = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const CheckBox = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-CheckBox.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CheckBox.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CheckBox;

--- a/src/icons/check-in.js
+++ b/src/icons/check-in.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CheckIn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const CheckIn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-CheckIn.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CheckIn.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CheckIn;

--- a/src/icons/check.js
+++ b/src/icons/check.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Check = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Check = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Check.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Check.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Check;

--- a/src/icons/chess.js
+++ b/src/icons/chess.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Chess = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Chess = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Chess.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Chess.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Chess;

--- a/src/icons/chevron-down-small.js
+++ b/src/icons/chevron-down-small.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronDownSmall = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ChevronDownSmall = ({
   );
 };
 
-ChevronDownSmall.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronDownSmall.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronDownSmall;

--- a/src/icons/chevron-down.js
+++ b/src/icons/chevron-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronDown = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ChevronDown = ({
   );
 };
 
-ChevronDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronDown;

--- a/src/icons/chevron-horizontal.js
+++ b/src/icons/chevron-horizontal.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronHorizontal = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ChevronHorizontal = ({
   );
 };
 
-ChevronHorizontal.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronHorizontal.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronHorizontal;

--- a/src/icons/chevron-left-small.js
+++ b/src/icons/chevron-left-small.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronLeftSmall = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ChevronLeftSmall = ({
   );
 };
 
-ChevronLeftSmall.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronLeftSmall.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronLeftSmall;

--- a/src/icons/chevron-left.js
+++ b/src/icons/chevron-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronLeft = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ChevronLeft = ({
   );
 };
 
-ChevronLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronLeft;

--- a/src/icons/chevron-right-small.js
+++ b/src/icons/chevron-right-small.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronRightSmall = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ChevronRightSmall = ({
   );
 };
 
-ChevronRightSmall.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronRightSmall.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronRightSmall;

--- a/src/icons/chevron-right.js
+++ b/src/icons/chevron-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronRight = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ChevronRight = ({
   );
 };
 
-ChevronRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronRight;

--- a/src/icons/chevron-up-small.js
+++ b/src/icons/chevron-up-small.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronUpSmall = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ChevronUpSmall = ({
   );
 };
 
-ChevronUpSmall.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronUpSmall.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronUpSmall;

--- a/src/icons/chevron-up.js
+++ b/src/icons/chevron-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const ChevronUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ChevronUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronUp;

--- a/src/icons/chevron-vertical.js
+++ b/src/icons/chevron-vertical.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ChevronVertical = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ChevronVertical = ({
   );
 };
 
-ChevronVertical.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ChevronVertical.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ChevronVertical;

--- a/src/icons/circle-alert-fill.js
+++ b/src/icons/circle-alert-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleAlertFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleAlertFill = ({
   );
 };
 
-CircleAlertFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleAlertFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleAlertFill;

--- a/src/icons/circle-alert.js
+++ b/src/icons/circle-alert.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleAlert = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleAlert = ({
   );
 };
 
-CircleAlert.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleAlert.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleAlert;

--- a/src/icons/circle-check-fill.js
+++ b/src/icons/circle-check-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleCheckFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleCheckFill = ({
   );
 };
 
-CircleCheckFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleCheckFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleCheckFill;

--- a/src/icons/circle-check.js
+++ b/src/icons/circle-check.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleCheck = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleCheck = ({
   );
 };
 
-CircleCheck.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleCheck.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleCheck;

--- a/src/icons/circle-chevron-down-fill.js
+++ b/src/icons/circle-chevron-down-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleChevronDownFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleChevronDownFill = ({
   );
 };
 
-CircleChevronDownFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleChevronDownFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleChevronDownFill;

--- a/src/icons/circle-chevron-down.js
+++ b/src/icons/circle-chevron-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleChevronDown = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleChevronDown = ({
   );
 };
 
-CircleChevronDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleChevronDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleChevronDown;

--- a/src/icons/circle-chevron-left-fill.js
+++ b/src/icons/circle-chevron-left-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleChevronLeftFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleChevronLeftFill = ({
   );
 };
 
-CircleChevronLeftFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleChevronLeftFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleChevronLeftFill;

--- a/src/icons/circle-chevron-left.js
+++ b/src/icons/circle-chevron-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleChevronLeft = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleChevronLeft = ({
   );
 };
 
-CircleChevronLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleChevronLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleChevronLeft;

--- a/src/icons/circle-chevron-right-fill.js
+++ b/src/icons/circle-chevron-right-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleChevronRightFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleChevronRightFill = ({
   );
 };
 
-CircleChevronRightFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleChevronRightFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleChevronRightFill;

--- a/src/icons/circle-chevron-right.js
+++ b/src/icons/circle-chevron-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleChevronRight = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleChevronRight = ({
   );
 };
 
-CircleChevronRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleChevronRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleChevronRight;

--- a/src/icons/circle-chevron-up-fill.js
+++ b/src/icons/circle-chevron-up-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleChevronUpFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleChevronUpFill = ({
   );
 };
 
-CircleChevronUpFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleChevronUpFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleChevronUpFill;

--- a/src/icons/circle-chevron-up.js
+++ b/src/icons/circle-chevron-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleChevronUp = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleChevronUp = ({
   );
 };
 
-CircleChevronUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleChevronUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleChevronUp;

--- a/src/icons/circle-fill.js
+++ b/src/icons/circle-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const CircleFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-CircleFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleFill;

--- a/src/icons/circle-minus-fill.js
+++ b/src/icons/circle-minus-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleMinusFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleMinusFill = ({
   );
 };
 
-CircleMinusFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleMinusFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleMinusFill;

--- a/src/icons/circle-minus.js
+++ b/src/icons/circle-minus.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleMinus = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleMinus = ({
   );
 };
 
-CircleMinus.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleMinus.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleMinus;

--- a/src/icons/circle-plus-fill.js
+++ b/src/icons/circle-plus-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CirclePlusFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CirclePlusFill = ({
   );
 };
 
-CirclePlusFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CirclePlusFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CirclePlusFill;

--- a/src/icons/circle-plus.js
+++ b/src/icons/circle-plus.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CirclePlus = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const CirclePlus = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-CirclePlus.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CirclePlus.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CirclePlus;

--- a/src/icons/circle-triangle-down-fill.js
+++ b/src/icons/circle-triangle-down-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleTriangleDownFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleTriangleDownFill = ({
   );
 };
 
-CircleTriangleDownFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleTriangleDownFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleTriangleDownFill;

--- a/src/icons/circle-triangle-down.js
+++ b/src/icons/circle-triangle-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleTriangleDown = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleTriangleDown = ({
   );
 };
 
-CircleTriangleDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleTriangleDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleTriangleDown;

--- a/src/icons/circle-triangle-left-fill.js
+++ b/src/icons/circle-triangle-left-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleTriangleLeftFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleTriangleLeftFill = ({
   );
 };
 
-CircleTriangleLeftFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleTriangleLeftFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleTriangleLeftFill;

--- a/src/icons/circle-triangle-left.js
+++ b/src/icons/circle-triangle-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleTriangleLeft = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleTriangleLeft = ({
   );
 };
 
-CircleTriangleLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleTriangleLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleTriangleLeft;

--- a/src/icons/circle-triangle-right-fill.js
+++ b/src/icons/circle-triangle-right-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleTriangleRightFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleTriangleRightFill = ({
   );
 };
 
-CircleTriangleRightFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleTriangleRightFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleTriangleRightFill;

--- a/src/icons/circle-triangle-right.js
+++ b/src/icons/circle-triangle-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleTriangleRight = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleTriangleRight = ({
   );
 };
 
-CircleTriangleRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleTriangleRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleTriangleRight;

--- a/src/icons/circle-triangle-up-fill.js
+++ b/src/icons/circle-triangle-up-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleTriangleUpFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleTriangleUpFill = ({
   );
 };
 
-CircleTriangleUpFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleTriangleUpFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleTriangleUpFill;

--- a/src/icons/circle-triangle-up.js
+++ b/src/icons/circle-triangle-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleTriangleUp = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CircleTriangleUp = ({
   );
 };
 
-CircleTriangleUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleTriangleUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleTriangleUp;

--- a/src/icons/circle-x-fill.js
+++ b/src/icons/circle-x-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleXFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const CircleXFill = ({
   );
 };
 
-CircleXFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleXFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleXFill;

--- a/src/icons/circle-x.js
+++ b/src/icons/circle-x.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CircleX = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const CircleX = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-CircleX.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CircleX.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CircleX;

--- a/src/icons/circle.js
+++ b/src/icons/circle.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Circle = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Circle = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Circle.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Circle.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Circle;

--- a/src/icons/clipboard.js
+++ b/src/icons/clipboard.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Clipboard = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Clipboard = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Clipboard.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Clipboard.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Clipboard;

--- a/src/icons/clock.js
+++ b/src/icons/clock.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Clock = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Clock = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Clock.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Clock.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Clock;

--- a/src/icons/cloud-download.js
+++ b/src/icons/cloud-download.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CloudDownload = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const CloudDownload = ({
   );
 };
 
-CloudDownload.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CloudDownload.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CloudDownload;

--- a/src/icons/cloud-upload.js
+++ b/src/icons/cloud-upload.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CloudUpload = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const CloudUpload = ({
   );
 };
 
-CloudUpload.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CloudUpload.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CloudUpload;

--- a/src/icons/cloud.js
+++ b/src/icons/cloud.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Cloud = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Cloud = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Cloud.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Cloud.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Cloud;

--- a/src/icons/codepen-fill.js
+++ b/src/icons/codepen-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CodepenFill = ({
   color = 'currentColor',
@@ -31,9 +30,13 @@ const CodepenFill = ({
   );
 };
 
-CodepenFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CodepenFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CodepenFill;

--- a/src/icons/coffee.js
+++ b/src/icons/coffee.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Coffee = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -25,9 +24,13 @@ const Coffee = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Coffee.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Coffee.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Coffee;

--- a/src/icons/coin.js
+++ b/src/icons/coin.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Coin = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -28,9 +27,13 @@ const Coin = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Coin.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Coin.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Coin;

--- a/src/icons/command.js
+++ b/src/icons/command.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Command = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Command = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Command.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Command.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Command;

--- a/src/icons/computing.js
+++ b/src/icons/computing.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Computing = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -28,9 +27,13 @@ const Computing = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Computing.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Computing.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Computing;

--- a/src/icons/copy.js
+++ b/src/icons/copy.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Copy = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Copy = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Copy.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Copy.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Copy;

--- a/src/icons/credit-card-alt1.js
+++ b/src/icons/credit-card-alt1.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CreditCardAlt1 = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const CreditCardAlt1 = ({
   );
 };
 
-CreditCardAlt1.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CreditCardAlt1.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CreditCardAlt1;

--- a/src/icons/credit-card.js
+++ b/src/icons/credit-card.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CreditCard = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const CreditCard = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-CreditCard.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CreditCard.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CreditCard;

--- a/src/icons/cross.js
+++ b/src/icons/cross.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Cross = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Cross = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Cross.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Cross.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Cross;

--- a/src/icons/crown.js
+++ b/src/icons/crown.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Crown = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Crown = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Crown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Crown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Crown;

--- a/src/icons/css-fill.js
+++ b/src/icons/css-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const CssFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const CssFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-CssFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  CssFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default CssFill;

--- a/src/icons/cursor.js
+++ b/src/icons/cursor.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Cursor = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Cursor = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Cursor.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Cursor.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Cursor;

--- a/src/icons/cut.js
+++ b/src/icons/cut.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Cut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Cut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Cut.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Cut.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Cut;

--- a/src/icons/dashboard.js
+++ b/src/icons/dashboard.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Dashboard = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Dashboard = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Dashboard.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Dashboard.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Dashboard;

--- a/src/icons/data.js
+++ b/src/icons/data.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Data = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Data = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Data.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Data.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Data;

--- a/src/icons/dental.js
+++ b/src/icons/dental.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Dental = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Dental = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Dental.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Dental.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Dental;

--- a/src/icons/descending.js
+++ b/src/icons/descending.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Descending = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Descending = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Descending.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Descending.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Descending;

--- a/src/icons/desktop-device.js
+++ b/src/icons/desktop-device.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DesktopDevice = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const DesktopDevice = ({
   );
 };
 
-DesktopDevice.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DesktopDevice.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DesktopDevice;

--- a/src/icons/devices.js
+++ b/src/icons/devices.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Devices = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Devices = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Devices.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Devices.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Devices;

--- a/src/icons/diamond.js
+++ b/src/icons/diamond.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Diamond = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Diamond = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Diamond.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Diamond.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Diamond;

--- a/src/icons/dice-1.js
+++ b/src/icons/dice-1.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Dice1 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Dice1 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Dice1.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Dice1.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Dice1;

--- a/src/icons/dice-2.js
+++ b/src/icons/dice-2.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Dice2 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Dice2 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Dice2.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Dice2.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Dice2;

--- a/src/icons/dice-3.js
+++ b/src/icons/dice-3.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Dice3 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -26,9 +25,13 @@ const Dice3 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Dice3.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Dice3.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Dice3;

--- a/src/icons/dice-4.js
+++ b/src/icons/dice-4.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Dice4 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -28,9 +27,13 @@ const Dice4 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Dice4.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Dice4.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Dice4;

--- a/src/icons/dice-5.js
+++ b/src/icons/dice-5.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Dice5 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -30,9 +29,13 @@ const Dice5 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Dice5.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Dice5.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Dice5;

--- a/src/icons/dice-6.js
+++ b/src/icons/dice-6.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Dice6 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -32,9 +31,13 @@ const Dice6 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Dice6.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Dice6.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Dice6;

--- a/src/icons/discord-fill.js
+++ b/src/icons/discord-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DiscordFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const DiscordFill = ({
   );
 };
 
-DiscordFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DiscordFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DiscordFill;

--- a/src/icons/django-fill.js
+++ b/src/icons/django-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DjangoFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const DjangoFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-DjangoFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DjangoFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DjangoFill;

--- a/src/icons/door.js
+++ b/src/icons/door.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Door = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Door = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Door.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Door.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Door;

--- a/src/icons/dot-grid-fill.js
+++ b/src/icons/dot-grid-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DotGridFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const DotGridFill = ({
   );
 };
 
-DotGridFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DotGridFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DotGridFill;

--- a/src/icons/double-check.js
+++ b/src/icons/double-check.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DoubleCheck = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const DoubleCheck = ({
   );
 };
 
-DoubleCheck.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DoubleCheck.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DoubleCheck;

--- a/src/icons/double-sword.js
+++ b/src/icons/double-sword.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DoubleSword = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const DoubleSword = ({
   );
 };
 
-DoubleSword.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DoubleSword.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DoubleSword;

--- a/src/icons/download.js
+++ b/src/icons/download.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Download = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Download = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Download.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Download.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Download;

--- a/src/icons/draft.js
+++ b/src/icons/draft.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Draft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Draft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Draft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Draft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Draft;

--- a/src/icons/drag-horizontal-fill.js
+++ b/src/icons/drag-horizontal-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DragHorizontalFill = ({
   color = 'currentColor',
@@ -49,9 +48,13 @@ const DragHorizontalFill = ({
   );
 };
 
-DragHorizontalFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DragHorizontalFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DragHorizontalFill;

--- a/src/icons/drag-vertical-fill.js
+++ b/src/icons/drag-vertical-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DragVerticalFill = ({
   color = 'currentColor',
@@ -49,9 +48,13 @@ const DragVerticalFill = ({
   );
 };
 
-DragVerticalFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DragVerticalFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DragVerticalFill;

--- a/src/icons/dribbble-fill.js
+++ b/src/icons/dribbble-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DribbbleFill = ({
   color = 'currentColor',
@@ -31,9 +30,13 @@ const DribbbleFill = ({
   );
 };
 
-DribbbleFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DribbbleFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DribbbleFill;

--- a/src/icons/dropbox-fill.js
+++ b/src/icons/dropbox-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const DropboxFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const DropboxFill = ({
   );
 };
 
-DropboxFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  DropboxFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default DropboxFill;

--- a/src/icons/edit.js
+++ b/src/icons/edit.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Edit = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Edit = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Edit.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Edit.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Edit;

--- a/src/icons/enlarge.js
+++ b/src/icons/enlarge.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Enlarge = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Enlarge = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Enlarge.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Enlarge.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Enlarge;

--- a/src/icons/envelope.js
+++ b/src/icons/envelope.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Envelope = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Envelope = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Envelope.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Envelope.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Envelope;

--- a/src/icons/equal-fill.js
+++ b/src/icons/equal-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const EqualFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const EqualFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-EqualFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  EqualFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default EqualFill;

--- a/src/icons/equal.js
+++ b/src/icons/equal.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Equal = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Equal = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Equal.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Equal.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Equal;

--- a/src/icons/eye-closed.js
+++ b/src/icons/eye-closed.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const EyeClosed = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const EyeClosed = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-EyeClosed.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  EyeClosed.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default EyeClosed;

--- a/src/icons/eye-open.js
+++ b/src/icons/eye-open.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const EyeOpen = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const EyeOpen = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-EyeOpen.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  EyeOpen.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default EyeOpen;

--- a/src/icons/eye-slashed.js
+++ b/src/icons/eye-slashed.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const EyeSlashed = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const EyeSlashed = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-EyeSlashed.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  EyeSlashed.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default EyeSlashed;

--- a/src/icons/face-happy.js
+++ b/src/icons/face-happy.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FaceHappy = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const FaceHappy = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-FaceHappy.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FaceHappy.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FaceHappy;

--- a/src/icons/face-neutral.js
+++ b/src/icons/face-neutral.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FaceNeutral = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const FaceNeutral = ({
   );
 };
 
-FaceNeutral.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FaceNeutral.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FaceNeutral;

--- a/src/icons/face-sad.js
+++ b/src/icons/face-sad.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FaceSad = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const FaceSad = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-FaceSad.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FaceSad.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FaceSad;

--- a/src/icons/face-very-happy.js
+++ b/src/icons/face-very-happy.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FaceVeryHappy = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const FaceVeryHappy = ({
   );
 };
 
-FaceVeryHappy.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FaceVeryHappy.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FaceVeryHappy;

--- a/src/icons/face-very-sad.js
+++ b/src/icons/face-very-sad.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FaceVerySad = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const FaceVerySad = ({
   );
 };
 
-FaceVerySad.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FaceVerySad.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FaceVerySad;

--- a/src/icons/face-wink.js
+++ b/src/icons/face-wink.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FaceWink = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const FaceWink = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-FaceWink.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FaceWink.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FaceWink;

--- a/src/icons/facebook-fill.js
+++ b/src/icons/facebook-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FacebookFill = ({
   color = 'currentColor',
@@ -31,9 +30,13 @@ const FacebookFill = ({
   );
 };
 
-FacebookFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FacebookFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FacebookFill;

--- a/src/icons/figma-fill.js
+++ b/src/icons/figma-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FigmaFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -27,9 +26,13 @@ const FigmaFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-FigmaFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FigmaFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FigmaFill;

--- a/src/icons/file.js
+++ b/src/icons/file.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const File = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const File = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-File.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  File.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default File;

--- a/src/icons/filter.js
+++ b/src/icons/filter.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Filter = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Filter = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Filter.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Filter.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Filter;

--- a/src/icons/fire.js
+++ b/src/icons/fire.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Fire = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Fire = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Fire.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Fire.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Fire;

--- a/src/icons/flag.js
+++ b/src/icons/flag.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Flag = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Flag = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Flag.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Flag.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Flag;

--- a/src/icons/flashlight.js
+++ b/src/icons/flashlight.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Flashlight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Flashlight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Flashlight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Flashlight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Flashlight;

--- a/src/icons/folder-add.js
+++ b/src/icons/folder-add.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FolderAdd = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const FolderAdd = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-FolderAdd.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FolderAdd.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FolderAdd;

--- a/src/icons/folder.js
+++ b/src/icons/folder.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Folder = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Folder = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Folder.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Folder.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Folder;

--- a/src/icons/fork-left.js
+++ b/src/icons/fork-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ForkLeft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const ForkLeft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ForkLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ForkLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ForkLeft;

--- a/src/icons/fork-right.js
+++ b/src/icons/fork-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ForkRight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const ForkRight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ForkRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ForkRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ForkRight;

--- a/src/icons/frame.js
+++ b/src/icons/frame.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Frame = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Frame = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Frame.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Frame.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Frame;

--- a/src/icons/full-screen.js
+++ b/src/icons/full-screen.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const FullScreen = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const FullScreen = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-FullScreen.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  FullScreen.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default FullScreen;

--- a/src/icons/game-controller.js
+++ b/src/icons/game-controller.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const GameController = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const GameController = ({
   );
 };
 
-GameController.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  GameController.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default GameController;

--- a/src/icons/gatsby-fill.js
+++ b/src/icons/gatsby-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const GatsbyFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const GatsbyFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-GatsbyFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  GatsbyFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default GatsbyFill;

--- a/src/icons/gear.js
+++ b/src/icons/gear.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Gear = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Gear = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Gear.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Gear.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Gear;

--- a/src/icons/gift.js
+++ b/src/icons/gift.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Gift = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Gift = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Gift.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Gift.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Gift;

--- a/src/icons/github-fill.js
+++ b/src/icons/github-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const GithubFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -27,9 +26,13 @@ const GithubFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-GithubFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  GithubFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default GithubFill;

--- a/src/icons/gitlab-fill.js
+++ b/src/icons/gitlab-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const GitlabFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const GitlabFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-GitlabFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  GitlabFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default GitlabFill;

--- a/src/icons/glasses.js
+++ b/src/icons/glasses.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Glasses = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Glasses = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Glasses.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Glasses.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Glasses;

--- a/src/icons/globe.js
+++ b/src/icons/globe.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Globe = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -28,9 +27,13 @@ const Globe = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Globe.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Globe.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Globe;

--- a/src/icons/google-contained-fill.js
+++ b/src/icons/google-contained-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const GoogleContainedFill = ({
   color = 'currentColor',
@@ -31,9 +30,13 @@ const GoogleContainedFill = ({
   );
 };
 
-GoogleContainedFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  GoogleContainedFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default GoogleContainedFill;

--- a/src/icons/google-fill.js
+++ b/src/icons/google-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const GoogleFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const GoogleFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-GoogleFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  GoogleFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default GoogleFill;

--- a/src/icons/graphql-fill.js
+++ b/src/icons/graphql-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const GraphqlFill = ({
   color = 'currentColor',
@@ -31,9 +30,13 @@ const GraphqlFill = ({
   );
 };
 
-GraphqlFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  GraphqlFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default GraphqlFill;

--- a/src/icons/grid.js
+++ b/src/icons/grid.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Grid = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Grid = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Grid.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Grid.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Grid;

--- a/src/icons/hammer.js
+++ b/src/icons/hammer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Hammer = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Hammer = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Hammer.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Hammer.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Hammer;

--- a/src/icons/hand.js
+++ b/src/icons/hand.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Hand = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Hand = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Hand.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Hand.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Hand;

--- a/src/icons/hashtag.js
+++ b/src/icons/hashtag.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Hashtag = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Hashtag = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Hashtag.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Hashtag.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Hashtag;

--- a/src/icons/headphone.js
+++ b/src/icons/headphone.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Headphone = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Headphone = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Headphone.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Headphone.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Headphone;

--- a/src/icons/health.js
+++ b/src/icons/health.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Health = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Health = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Health.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Health.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Health;

--- a/src/icons/heart.js
+++ b/src/icons/heart.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Heart = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Heart = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Heart.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Heart.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Heart;

--- a/src/icons/height.js
+++ b/src/icons/height.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Height = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Height = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Height.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Height.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Height;

--- a/src/icons/heptagon-fill.js
+++ b/src/icons/heptagon-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const HeptagonFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const HeptagonFill = ({
   );
 };
 
-HeptagonFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  HeptagonFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default HeptagonFill;

--- a/src/icons/heptagon.js
+++ b/src/icons/heptagon.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Heptagon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Heptagon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Heptagon.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Heptagon.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Heptagon;

--- a/src/icons/hexagon-fill.js
+++ b/src/icons/hexagon-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const HexagonFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const HexagonFill = ({
   );
 };
 
-HexagonFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  HexagonFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default HexagonFill;

--- a/src/icons/hexagon.js
+++ b/src/icons/hexagon.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Hexagon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Hexagon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Hexagon.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Hexagon.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Hexagon;

--- a/src/icons/history.js
+++ b/src/icons/history.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const History = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const History = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-History.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  History.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default History;

--- a/src/icons/home-alt1.js
+++ b/src/icons/home-alt1.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const HomeAlt1 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const HomeAlt1 = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-HomeAlt1.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  HomeAlt1.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default HomeAlt1;

--- a/src/icons/home.js
+++ b/src/icons/home.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Home = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Home = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Home.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Home.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Home;

--- a/src/icons/html-fill.js
+++ b/src/icons/html-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const HtmlFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -31,9 +30,13 @@ const HtmlFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-HtmlFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  HtmlFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default HtmlFill;

--- a/src/icons/image.js
+++ b/src/icons/image.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Image = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Image = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Image.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Image.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Image;

--- a/src/icons/inbox.js
+++ b/src/icons/inbox.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Inbox = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Inbox = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Inbox.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Inbox.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Inbox;

--- a/src/icons/infinite.js
+++ b/src/icons/infinite.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Infinite = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Infinite = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Infinite.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Infinite.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Infinite;

--- a/src/icons/info-fill.js
+++ b/src/icons/info-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const InfoFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const InfoFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-InfoFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  InfoFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default InfoFill;

--- a/src/icons/info.js
+++ b/src/icons/info.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Info = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Info = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Info.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Info.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Info;

--- a/src/icons/instagram-fill.js
+++ b/src/icons/instagram-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const InstagramFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const InstagramFill = ({
   );
 };
 
-InstagramFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  InstagramFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default InstagramFill;

--- a/src/icons/jar.js
+++ b/src/icons/jar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Jar = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Jar = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Jar.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Jar.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Jar;

--- a/src/icons/javascript-fill.js
+++ b/src/icons/javascript-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const JavascriptFill = ({
   color = 'currentColor',
@@ -31,9 +30,13 @@ const JavascriptFill = ({
   );
 };
 
-JavascriptFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  JavascriptFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default JavascriptFill;

--- a/src/icons/jquery-fill.js
+++ b/src/icons/jquery-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const JqueryFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -25,9 +24,13 @@ const JqueryFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-JqueryFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  JqueryFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default JqueryFill;

--- a/src/icons/key-cap.js
+++ b/src/icons/key-cap.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const KeyCap = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const KeyCap = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-KeyCap.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  KeyCap.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default KeyCap;

--- a/src/icons/key.js
+++ b/src/icons/key.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Key = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Key = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Key.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Key.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Key;

--- a/src/icons/language.js
+++ b/src/icons/language.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Language = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Language = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Language.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Language.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Language;

--- a/src/icons/laptop-device.js
+++ b/src/icons/laptop-device.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LaptopDevice = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const LaptopDevice = ({
   );
 };
 
-LaptopDevice.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LaptopDevice.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LaptopDevice;

--- a/src/icons/leaf.js
+++ b/src/icons/leaf.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Leaf = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Leaf = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Leaf.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Leaf.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Leaf;

--- a/src/icons/lifesaver.js
+++ b/src/icons/lifesaver.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Lifesaver = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -32,9 +31,13 @@ const Lifesaver = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Lifesaver.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Lifesaver.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Lifesaver;

--- a/src/icons/light-bulb.js
+++ b/src/icons/light-bulb.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LightBulb = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const LightBulb = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-LightBulb.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LightBulb.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LightBulb;

--- a/src/icons/link-chain.js
+++ b/src/icons/link-chain.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LinkChain = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const LinkChain = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-LinkChain.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LinkChain.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LinkChain;

--- a/src/icons/link-off.js
+++ b/src/icons/link-off.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LinkOff = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const LinkOff = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-LinkOff.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LinkOff.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LinkOff;

--- a/src/icons/link-on.js
+++ b/src/icons/link-on.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LinkOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const LinkOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-LinkOn.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LinkOn.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LinkOn;

--- a/src/icons/link-out.js
+++ b/src/icons/link-out.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LinkOut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const LinkOut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-LinkOut.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LinkOut.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LinkOut;

--- a/src/icons/linkedin-box-fill.js
+++ b/src/icons/linkedin-box-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LinkedinBoxFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const LinkedinBoxFill = ({
   );
 };
 
-LinkedinBoxFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LinkedinBoxFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LinkedinBoxFill;

--- a/src/icons/linkedin-fill.js
+++ b/src/icons/linkedin-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LinkedinFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const LinkedinFill = ({
   );
 };
 
-LinkedinFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LinkedinFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LinkedinFill;

--- a/src/icons/location.js
+++ b/src/icons/location.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Location = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Location = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Location.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Location.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Location;

--- a/src/icons/lock-off.js
+++ b/src/icons/lock-off.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LockOff = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const LockOff = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-LockOff.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LockOff.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LockOff;

--- a/src/icons/lock-on.js
+++ b/src/icons/lock-on.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const LockOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const LockOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-LockOn.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  LockOn.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default LockOn;

--- a/src/icons/map.js
+++ b/src/icons/map.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Map = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Map = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Map.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Map.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Map;

--- a/src/icons/mastodon-fill.js
+++ b/src/icons/mastodon-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MastodonFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const MastodonFill = ({
   );
 };
 
-MastodonFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MastodonFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MastodonFill;

--- a/src/icons/medium-fill.js
+++ b/src/icons/medium-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MediumFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const MediumFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-MediumFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MediumFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MediumFill;

--- a/src/icons/mention.js
+++ b/src/icons/mention.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Mention = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Mention = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Mention.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Mention.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Mention;

--- a/src/icons/microphone.js
+++ b/src/icons/microphone.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Microphone = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Microphone = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Microphone.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Microphone.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Microphone;

--- a/src/icons/miniplayer.js
+++ b/src/icons/miniplayer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Miniplayer = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Miniplayer = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Miniplayer.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Miniplayer.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Miniplayer;

--- a/src/icons/minus.js
+++ b/src/icons/minus.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Minus = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Minus = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Minus.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Minus.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Minus;

--- a/src/icons/mobile-device.js
+++ b/src/icons/mobile-device.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MobileDevice = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const MobileDevice = ({
   );
 };
 
-MobileDevice.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MobileDevice.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MobileDevice;

--- a/src/icons/money.js
+++ b/src/icons/money.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Money = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Money = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Money.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Money.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Money;

--- a/src/icons/moon-fill.js
+++ b/src/icons/moon-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MoonFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -17,9 +16,13 @@ const MoonFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-MoonFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MoonFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MoonFill;

--- a/src/icons/moon.js
+++ b/src/icons/moon.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Moon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Moon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Moon.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Moon.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Moon;

--- a/src/icons/more-horizontal-fill.js
+++ b/src/icons/more-horizontal-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MoreHorizontalFill = ({
   color = 'currentColor',
@@ -34,9 +33,13 @@ const MoreHorizontalFill = ({
   );
 };
 
-MoreHorizontalFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MoreHorizontalFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MoreHorizontalFill;

--- a/src/icons/more-vertical-fill.js
+++ b/src/icons/more-vertical-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MoreVerticalFill = ({
   color = 'currentColor',
@@ -34,9 +33,13 @@ const MoreVerticalFill = ({
   );
 };
 
-MoreVerticalFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MoreVerticalFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MoreVerticalFill;

--- a/src/icons/music-album-fill.js
+++ b/src/icons/music-album-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MusicAlbumFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const MusicAlbumFill = ({
   );
 };
 
-MusicAlbumFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MusicAlbumFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MusicAlbumFill;

--- a/src/icons/music-album.js
+++ b/src/icons/music-album.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MusicAlbum = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const MusicAlbum = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-MusicAlbum.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MusicAlbum.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MusicAlbum;

--- a/src/icons/music-note.js
+++ b/src/icons/music-note.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const MusicNote = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const MusicNote = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-MusicNote.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  MusicNote.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default MusicNote;

--- a/src/icons/music.js
+++ b/src/icons/music.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Music = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Music = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Music.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Music.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Music;

--- a/src/icons/network.js
+++ b/src/icons/network.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Network = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Network = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Network.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Network.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Network;

--- a/src/icons/newspaper.js
+++ b/src/icons/newspaper.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Newspaper = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Newspaper = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Newspaper.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Newspaper.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Newspaper;

--- a/src/icons/nextjs-fill.js
+++ b/src/icons/nextjs-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const NextjsFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const NextjsFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-NextjsFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  NextjsFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default NextjsFill;

--- a/src/icons/node-fill.js
+++ b/src/icons/node-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const NodeFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const NodeFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-NodeFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  NodeFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default NodeFill;

--- a/src/icons/normal-screen.js
+++ b/src/icons/normal-screen.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const NormalScreen = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const NormalScreen = ({
   );
 };
 
-NormalScreen.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  NormalScreen.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default NormalScreen;

--- a/src/icons/npm-fill.js
+++ b/src/icons/npm-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const NpmFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -27,9 +26,13 @@ const NpmFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-NpmFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  NpmFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default NpmFill;

--- a/src/icons/octagon-fill.js
+++ b/src/icons/octagon-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const OctagonFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const OctagonFill = ({
   );
 };
 
-OctagonFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  OctagonFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default OctagonFill;

--- a/src/icons/octagon.js
+++ b/src/icons/octagon.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Octagon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Octagon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Octagon.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Octagon.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Octagon;

--- a/src/icons/octocat-fill.js
+++ b/src/icons/octocat-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const OctocatFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const OctocatFill = ({
   );
 };
 
-OctocatFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  OctocatFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default OctocatFill;

--- a/src/icons/open-envelope.js
+++ b/src/icons/open-envelope.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const OpenEnvelope = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const OpenEnvelope = ({
   );
 };
 
-OpenEnvelope.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  OpenEnvelope.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default OpenEnvelope;

--- a/src/icons/oval.js
+++ b/src/icons/oval.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Oval = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Oval = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Oval.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Oval.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Oval;

--- a/src/icons/panel-bottom.js
+++ b/src/icons/panel-bottom.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PanelBottom = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const PanelBottom = ({
   );
 };
 
-PanelBottom.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PanelBottom.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PanelBottom;

--- a/src/icons/panel-left.js
+++ b/src/icons/panel-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PanelLeft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const PanelLeft = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PanelLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PanelLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PanelLeft;

--- a/src/icons/panel-right.js
+++ b/src/icons/panel-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PanelRight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const PanelRight = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PanelRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PanelRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PanelRight;

--- a/src/icons/panel-split-column.js
+++ b/src/icons/panel-split-column.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PanelSplitColumn = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const PanelSplitColumn = ({
   );
 };
 
-PanelSplitColumn.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PanelSplitColumn.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PanelSplitColumn;

--- a/src/icons/panel-split-row.js
+++ b/src/icons/panel-split-row.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PanelSplitRow = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const PanelSplitRow = ({
   );
 };
 
-PanelSplitRow.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PanelSplitRow.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PanelSplitRow;

--- a/src/icons/panel-split.js
+++ b/src/icons/panel-split.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PanelSplit = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const PanelSplit = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PanelSplit.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PanelSplit.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PanelSplit;

--- a/src/icons/panel-top.js
+++ b/src/icons/panel-top.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PanelTop = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const PanelTop = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PanelTop.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PanelTop.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PanelTop;

--- a/src/icons/paper-airplane.js
+++ b/src/icons/paper-airplane.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PaperAirplane = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const PaperAirplane = ({
   );
 };
 
-PaperAirplane.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PaperAirplane.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PaperAirplane;

--- a/src/icons/paper.js
+++ b/src/icons/paper.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Paper = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Paper = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Paper.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Paper.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Paper;

--- a/src/icons/parallelogram.js
+++ b/src/icons/parallelogram.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Parallelogram = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const Parallelogram = ({
   );
 };
 
-Parallelogram.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Parallelogram.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Parallelogram;

--- a/src/icons/pause.js
+++ b/src/icons/pause.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Pause = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Pause = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Pause.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Pause.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Pause;

--- a/src/icons/pencil.js
+++ b/src/icons/pencil.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Pencil = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Pencil = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Pencil.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Pencil.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Pencil;

--- a/src/icons/pentagon-fill.js
+++ b/src/icons/pentagon-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PentagonFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const PentagonFill = ({
   );
 };
 
-PentagonFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PentagonFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PentagonFill;

--- a/src/icons/pentagon.js
+++ b/src/icons/pentagon.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Pentagon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Pentagon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Pentagon.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Pentagon.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Pentagon;

--- a/src/icons/people-group.js
+++ b/src/icons/people-group.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PeopleGroup = ({
   color = 'currentColor',
@@ -29,9 +28,13 @@ const PeopleGroup = ({
   );
 };
 
-PeopleGroup.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PeopleGroup.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PeopleGroup;

--- a/src/icons/people-multiple.js
+++ b/src/icons/people-multiple.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PeopleMultiple = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const PeopleMultiple = ({
   );
 };
 
-PeopleMultiple.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PeopleMultiple.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PeopleMultiple;

--- a/src/icons/percentage.js
+++ b/src/icons/percentage.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Percentage = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Percentage = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Percentage.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Percentage.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Percentage;

--- a/src/icons/person-add.js
+++ b/src/icons/person-add.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PersonAdd = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const PersonAdd = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PersonAdd.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PersonAdd.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PersonAdd;

--- a/src/icons/person-check.js
+++ b/src/icons/person-check.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PersonCheck = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const PersonCheck = ({
   );
 };
 
-PersonCheck.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PersonCheck.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PersonCheck;

--- a/src/icons/person-cross.js
+++ b/src/icons/person-cross.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PersonCross = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const PersonCross = ({
   );
 };
 
-PersonCross.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PersonCross.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PersonCross;

--- a/src/icons/person.js
+++ b/src/icons/person.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Person = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Person = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Person.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Person.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Person;

--- a/src/icons/phone.js
+++ b/src/icons/phone.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Phone = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Phone = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Phone.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Phone.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Phone;

--- a/src/icons/php-fill.js
+++ b/src/icons/php-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PhpFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const PhpFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PhpFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PhpFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PhpFill;

--- a/src/icons/pin.js
+++ b/src/icons/pin.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Pin = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Pin = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Pin.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Pin.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Pin;

--- a/src/icons/pinterest-fill.js
+++ b/src/icons/pinterest-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PinterestFill = ({
   color = 'currentColor',
@@ -32,9 +31,13 @@ const PinterestFill = ({
   );
 };
 
-PinterestFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PinterestFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PinterestFill;

--- a/src/icons/plane-fill.js
+++ b/src/icons/plane-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PlaneFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const PlaneFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PlaneFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PlaneFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PlaneFill;

--- a/src/icons/plane.js
+++ b/src/icons/plane.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Plane = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Plane = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Plane.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Plane.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Plane;

--- a/src/icons/planet.js
+++ b/src/icons/planet.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Planet = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Planet = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Planet.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Planet.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Planet;

--- a/src/icons/plant.js
+++ b/src/icons/plant.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Plant = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Plant = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Plant.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Plant.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Plant;

--- a/src/icons/play.js
+++ b/src/icons/play.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Play = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Play = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Play.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Play.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Play;

--- a/src/icons/plus.js
+++ b/src/icons/plus.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Plus = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Plus = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Plus.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Plus.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Plus;

--- a/src/icons/pointer-down-fill.js
+++ b/src/icons/pointer-down-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PointerDownFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const PointerDownFill = ({
   );
 };
 
-PointerDownFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PointerDownFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PointerDownFill;

--- a/src/icons/pointer-hand.js
+++ b/src/icons/pointer-hand.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PointerHand = ({
   color = 'currentColor',
@@ -28,9 +27,13 @@ const PointerHand = ({
   );
 };
 
-PointerHand.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PointerHand.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PointerHand;

--- a/src/icons/pointer-left-fill.js
+++ b/src/icons/pointer-left-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PointerLeftFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const PointerLeftFill = ({
   );
 };
 
-PointerLeftFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PointerLeftFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PointerLeftFill;

--- a/src/icons/pointer-right-fill.js
+++ b/src/icons/pointer-right-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PointerRightFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const PointerRightFill = ({
   );
 };
 
-PointerRightFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PointerRightFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PointerRightFill;

--- a/src/icons/pointer-up-fill.js
+++ b/src/icons/pointer-up-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PointerUpFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const PointerUpFill = ({
   );
 };
 
-PointerUpFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PointerUpFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PointerUpFill;

--- a/src/icons/pointing-up.js
+++ b/src/icons/pointing-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PointingUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -25,9 +24,13 @@ const PointingUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PointingUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PointingUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PointingUp;

--- a/src/icons/postgresql-fill.js
+++ b/src/icons/postgresql-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PostgresqlFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const PostgresqlFill = ({
   );
 };
 
-PostgresqlFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PostgresqlFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PostgresqlFill;

--- a/src/icons/price-cut.js
+++ b/src/icons/price-cut.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PriceCut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const PriceCut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PriceCut.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PriceCut.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PriceCut;

--- a/src/icons/product-hunt-fill.js
+++ b/src/icons/product-hunt-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ProductHuntFill = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const ProductHuntFill = ({
   );
 };
 
-ProductHuntFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ProductHuntFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ProductHuntFill;

--- a/src/icons/python-fill.js
+++ b/src/icons/python-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const PythonFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const PythonFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-PythonFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  PythonFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default PythonFill;

--- a/src/icons/question-fill.js
+++ b/src/icons/question-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const QuestionFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const QuestionFill = ({
   );
 };
 
-QuestionFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  QuestionFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default QuestionFill;

--- a/src/icons/question.js
+++ b/src/icons/question.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Question = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Question = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Question.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Question.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Question;

--- a/src/icons/radio-fill.js
+++ b/src/icons/radio-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const RadioFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const RadioFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-RadioFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  RadioFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default RadioFill;

--- a/src/icons/radio.js
+++ b/src/icons/radio.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Radio = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Radio = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Radio.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Radio.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Radio;

--- a/src/icons/radish.js
+++ b/src/icons/radish.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Radish = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Radish = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Radish.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Radish.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Radish;

--- a/src/icons/react-fill.js
+++ b/src/icons/react-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ReactFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const ReactFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ReactFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ReactFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ReactFill;

--- a/src/icons/receipt.js
+++ b/src/icons/receipt.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Receipt = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Receipt = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Receipt.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Receipt.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Receipt;

--- a/src/icons/reddit-fill.js
+++ b/src/icons/reddit-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const RedditFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -27,9 +26,13 @@ const RedditFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-RedditFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  RedditFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default RedditFill;

--- a/src/icons/reduce.js
+++ b/src/icons/reduce.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Reduce = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Reduce = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Reduce.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Reduce.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Reduce;

--- a/src/icons/redux-fill.js
+++ b/src/icons/redux-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ReduxFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const ReduxFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ReduxFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ReduxFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ReduxFill;

--- a/src/icons/ribbon.js
+++ b/src/icons/ribbon.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Ribbon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Ribbon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Ribbon.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Ribbon.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Ribbon;

--- a/src/icons/rock-on.js
+++ b/src/icons/rock-on.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const RockOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -25,9 +24,13 @@ const RockOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-RockOn.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  RockOn.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default RockOn;

--- a/src/icons/rss.js
+++ b/src/icons/rss.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Rss = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Rss = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Rss.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Rss.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Rss;

--- a/src/icons/sass-fill.js
+++ b/src/icons/sass-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SassFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const SassFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SassFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SassFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SassFill;

--- a/src/icons/save.js
+++ b/src/icons/save.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Save = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Save = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Save.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Save.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Save;

--- a/src/icons/schedule.js
+++ b/src/icons/schedule.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Schedule = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -25,9 +24,13 @@ const Schedule = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Schedule.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Schedule.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Schedule;

--- a/src/icons/scissor.js
+++ b/src/icons/scissor.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Scissor = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Scissor = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Scissor.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Scissor.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Scissor;

--- a/src/icons/search.js
+++ b/src/icons/search.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Search = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Search = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Search.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Search.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Search;

--- a/src/icons/send.js
+++ b/src/icons/send.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Send = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Send = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Send.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Send.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Send;

--- a/src/icons/settings-horizontal.js
+++ b/src/icons/settings-horizontal.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SettingsHorizontal = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const SettingsHorizontal = ({
   );
 };
 
-SettingsHorizontal.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SettingsHorizontal.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SettingsHorizontal;

--- a/src/icons/settings-vertical.js
+++ b/src/icons/settings-vertical.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SettingsVertical = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const SettingsVertical = ({
   );
 };
 
-SettingsVertical.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SettingsVertical.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SettingsVertical;

--- a/src/icons/share-box.js
+++ b/src/icons/share-box.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ShareBox = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ShareBox = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ShareBox.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ShareBox.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ShareBox;

--- a/src/icons/shield.js
+++ b/src/icons/shield.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Shield = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Shield = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Shield.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Shield.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Shield;

--- a/src/icons/shipping-box-v1.js
+++ b/src/icons/shipping-box-v1.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ShippingBoxV1 = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const ShippingBoxV1 = ({
   );
 };
 
-ShippingBoxV1.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ShippingBoxV1.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ShippingBoxV1;

--- a/src/icons/shipping-box-v2.js
+++ b/src/icons/shipping-box-v2.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ShippingBoxV2 = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const ShippingBoxV2 = ({
   );
 };
 
-ShippingBoxV2.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ShippingBoxV2.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ShippingBoxV2;

--- a/src/icons/shopping-bag.js
+++ b/src/icons/shopping-bag.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ShoppingBag = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const ShoppingBag = ({
   );
 };
 
-ShoppingBag.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ShoppingBag.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ShoppingBag;

--- a/src/icons/sign-out.js
+++ b/src/icons/sign-out.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SignOut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const SignOut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SignOut.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SignOut.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SignOut;

--- a/src/icons/slack-fill.js
+++ b/src/icons/slack-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SlackFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -35,9 +34,13 @@ const SlackFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SlackFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SlackFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SlackFill;

--- a/src/icons/slice.js
+++ b/src/icons/slice.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Slice = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Slice = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Slice.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Slice.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Slice;

--- a/src/icons/snapchat-fill.js
+++ b/src/icons/snapchat-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SnapchatFill = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const SnapchatFill = ({
   );
 };
 
-SnapchatFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SnapchatFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SnapchatFill;

--- a/src/icons/sort.js
+++ b/src/icons/sort.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Sort = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Sort = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Sort.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Sort.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Sort;

--- a/src/icons/sound-down.js
+++ b/src/icons/sound-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SoundDown = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const SoundDown = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SoundDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SoundDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SoundDown;

--- a/src/icons/sound-off.js
+++ b/src/icons/sound-off.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SoundOff = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const SoundOff = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SoundOff.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SoundOff.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SoundOff;

--- a/src/icons/sound-on.js
+++ b/src/icons/sound-on.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SoundOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const SoundOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SoundOn.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SoundOn.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SoundOn;

--- a/src/icons/sound-up.js
+++ b/src/icons/sound-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SoundUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const SoundUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SoundUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SoundUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SoundUp;

--- a/src/icons/soundcloud-fill.js
+++ b/src/icons/soundcloud-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SoundcloudFill = ({
   color = 'currentColor',
@@ -33,9 +32,13 @@ const SoundcloudFill = ({
   );
 };
 
-SoundcloudFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SoundcloudFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SoundcloudFill;

--- a/src/icons/sparkles.js
+++ b/src/icons/sparkles.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Sparkles = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Sparkles = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Sparkles.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Sparkles.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Sparkles;

--- a/src/icons/spotify-fill.js
+++ b/src/icons/spotify-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SpotifyFill = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const SpotifyFill = ({
   );
 };
 
-SpotifyFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SpotifyFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SpotifyFill;

--- a/src/icons/square-fill.js
+++ b/src/icons/square-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SquareFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const SquareFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SquareFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SquareFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SquareFill;

--- a/src/icons/square.js
+++ b/src/icons/square.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Square = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Square = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Square.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Square.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Square;

--- a/src/icons/stack-overflow-fill.js
+++ b/src/icons/stack-overflow-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const StackOverflowFill = ({
   color = 'currentColor',
@@ -21,9 +20,13 @@ const StackOverflowFill = ({
   );
 };
 
-StackOverflowFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  StackOverflowFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default StackOverflowFill;

--- a/src/icons/star.js
+++ b/src/icons/star.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Star = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Star = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Star.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Star.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Star;

--- a/src/icons/statistic-down.js
+++ b/src/icons/statistic-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const StatisticDown = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const StatisticDown = ({
   );
 };
 
-StatisticDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  StatisticDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default StatisticDown;

--- a/src/icons/statistic-up.js
+++ b/src/icons/statistic-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const StatisticUp = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const StatisticUp = ({
   );
 };
 
-StatisticUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  StatisticUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default StatisticUp;

--- a/src/icons/stop-fill.js
+++ b/src/icons/stop-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const StopFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const StopFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-StopFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  StopFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default StopFill;

--- a/src/icons/stop.js
+++ b/src/icons/stop.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Stop = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Stop = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Stop.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Stop.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Stop;

--- a/src/icons/sun-fill.js
+++ b/src/icons/sun-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const SunFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const SunFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-SunFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  SunFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default SunFill;

--- a/src/icons/sun.js
+++ b/src/icons/sun.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Sun = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Sun = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Sun.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Sun.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Sun;

--- a/src/icons/sword.js
+++ b/src/icons/sword.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Sword = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Sword = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Sword.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Sword.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Sword;

--- a/src/icons/tablet-device.js
+++ b/src/icons/tablet-device.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TabletDevice = ({
   color = 'currentColor',
@@ -25,9 +24,13 @@ const TabletDevice = ({
   );
 };
 
-TabletDevice.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TabletDevice.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TabletDevice;

--- a/src/icons/tag.js
+++ b/src/icons/tag.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Tag = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Tag = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Tag.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Tag.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Tag;

--- a/src/icons/telegram-fill.js
+++ b/src/icons/telegram-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TelegramFill = ({
   color = 'currentColor',
@@ -31,9 +30,13 @@ const TelegramFill = ({
   );
 };
 
-TelegramFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TelegramFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TelegramFill;

--- a/src/icons/telescope.js
+++ b/src/icons/telescope.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Telescope = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Telescope = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Telescope.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Telescope.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Telescope;

--- a/src/icons/tetragon-fill.js
+++ b/src/icons/tetragon-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TetragonFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const TetragonFill = ({
   );
 };
 
-TetragonFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TetragonFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TetragonFill;

--- a/src/icons/tetragon.js
+++ b/src/icons/tetragon.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Tetragon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Tetragon = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Tetragon.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Tetragon.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Tetragon;

--- a/src/icons/text-align-center.js
+++ b/src/icons/text-align-center.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TextAlignCenter = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TextAlignCenter = ({
   );
 };
 
-TextAlignCenter.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TextAlignCenter.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TextAlignCenter;

--- a/src/icons/text-align-justified.js
+++ b/src/icons/text-align-justified.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TextAlignJustified = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TextAlignJustified = ({
   );
 };
 
-TextAlignJustified.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TextAlignJustified.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TextAlignJustified;

--- a/src/icons/text-align-left.js
+++ b/src/icons/text-align-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TextAlignLeft = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TextAlignLeft = ({
   );
 };
 
-TextAlignLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TextAlignLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TextAlignLeft;

--- a/src/icons/text-align-right.js
+++ b/src/icons/text-align-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TextAlignRight = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TextAlignRight = ({
   );
 };
 
-TextAlignRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TextAlignRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TextAlignRight;

--- a/src/icons/threads-fill.js
+++ b/src/icons/threads-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ThreadsFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const ThreadsFill = ({
   );
 };
 
-ThreadsFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ThreadsFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ThreadsFill;

--- a/src/icons/three-line-horizontal.js
+++ b/src/icons/three-line-horizontal.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ThreeLineHorizontal = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ThreeLineHorizontal = ({
   );
 };
 
-ThreeLineHorizontal.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ThreeLineHorizontal.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ThreeLineHorizontal;

--- a/src/icons/three-line-vertical.js
+++ b/src/icons/three-line-vertical.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ThreeLineVertical = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ThreeLineVertical = ({
   );
 };
 
-ThreeLineVertical.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ThreeLineVertical.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ThreeLineVertical;

--- a/src/icons/thumbs-down.js
+++ b/src/icons/thumbs-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ThumbsDown = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ThumbsDown = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ThumbsDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ThumbsDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ThumbsDown;

--- a/src/icons/thumbs-up.js
+++ b/src/icons/thumbs-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ThumbsUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ThumbsUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ThumbsUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ThumbsUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ThumbsUp;

--- a/src/icons/thunder.js
+++ b/src/icons/thunder.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Thunder = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Thunder = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Thunder.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Thunder.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Thunder;

--- a/src/icons/ticket.js
+++ b/src/icons/ticket.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Ticket = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Ticket = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Ticket.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Ticket.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Ticket;

--- a/src/icons/tiktok-fill.js
+++ b/src/icons/tiktok-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TiktokFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const TiktokFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-TiktokFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TiktokFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TiktokFill;

--- a/src/icons/toggle-off-fill.js
+++ b/src/icons/toggle-off-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ToggleOffFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ToggleOffFill = ({
   );
 };
 
-ToggleOffFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ToggleOffFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ToggleOffFill;

--- a/src/icons/toggle-off.js
+++ b/src/icons/toggle-off.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ToggleOff = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ToggleOff = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ToggleOff.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ToggleOff.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ToggleOff;

--- a/src/icons/toggle-on-fill.js
+++ b/src/icons/toggle-on-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ToggleOnFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const ToggleOnFill = ({
   );
 };
 
-ToggleOnFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ToggleOnFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ToggleOnFill;

--- a/src/icons/toggle-on.js
+++ b/src/icons/toggle-on.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ToggleOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ToggleOn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ToggleOn.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ToggleOn.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ToggleOn;

--- a/src/icons/togo-cup.js
+++ b/src/icons/togo-cup.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TogoCup = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const TogoCup = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-TogoCup.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TogoCup.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TogoCup;

--- a/src/icons/trash-bin.js
+++ b/src/icons/trash-bin.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TrashBin = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const TrashBin = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-TrashBin.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TrashBin.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TrashBin;

--- a/src/icons/trash-can.js
+++ b/src/icons/trash-can.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TrashCan = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const TrashCan = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-TrashCan.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TrashCan.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TrashCan;

--- a/src/icons/triangle-alert-fill.js
+++ b/src/icons/triangle-alert-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleAlertFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TriangleAlertFill = ({
   );
 };
 
-TriangleAlertFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleAlertFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleAlertFill;

--- a/src/icons/triangle-alert.js
+++ b/src/icons/triangle-alert.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleAlert = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const TriangleAlert = ({
   );
 };
 
-TriangleAlert.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleAlert.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleAlert;

--- a/src/icons/triangle-down-fill.js
+++ b/src/icons/triangle-down-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleDownFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const TriangleDownFill = ({
   );
 };
 
-TriangleDownFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleDownFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleDownFill;

--- a/src/icons/triangle-down.js
+++ b/src/icons/triangle-down.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleDown = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TriangleDown = ({
   );
 };
 
-TriangleDown.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleDown.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleDown;

--- a/src/icons/triangle-fill.js
+++ b/src/icons/triangle-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const TriangleFill = ({
   );
 };
 
-TriangleFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleFill;

--- a/src/icons/triangle-left-fill.js
+++ b/src/icons/triangle-left-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleLeftFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const TriangleLeftFill = ({
   );
 };
 
-TriangleLeftFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleLeftFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleLeftFill;

--- a/src/icons/triangle-left.js
+++ b/src/icons/triangle-left.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleLeft = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TriangleLeft = ({
   );
 };
 
-TriangleLeft.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleLeft.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleLeft;

--- a/src/icons/triangle-right-fill.js
+++ b/src/icons/triangle-right-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleRightFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const TriangleRightFill = ({
   );
 };
 
-TriangleRightFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleRightFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleRightFill;

--- a/src/icons/triangle-right.js
+++ b/src/icons/triangle-right.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleRight = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TriangleRight = ({
   );
 };
 
-TriangleRight.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleRight.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleRight;

--- a/src/icons/triangle-up-fill.js
+++ b/src/icons/triangle-up-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleUpFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const TriangleUpFill = ({
   );
 };
 
-TriangleUpFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleUpFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleUpFill;

--- a/src/icons/triangle-up.js
+++ b/src/icons/triangle-up.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TriangleUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const TriangleUp = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-TriangleUp.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TriangleUp.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TriangleUp;

--- a/src/icons/triangle.js
+++ b/src/icons/triangle.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Triangle = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Triangle = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Triangle.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Triangle.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Triangle;

--- a/src/icons/trophy.js
+++ b/src/icons/trophy.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Trophy = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const Trophy = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Trophy.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Trophy.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Trophy;

--- a/src/icons/truck.js
+++ b/src/icons/truck.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Truck = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -24,9 +23,13 @@ const Truck = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Truck.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Truck.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Truck;

--- a/src/icons/tumblr-fill.js
+++ b/src/icons/tumblr-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TumblrFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const TumblrFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-TumblrFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TumblrFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TumblrFill;

--- a/src/icons/twitch-fill.js
+++ b/src/icons/twitch-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TwitchFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const TwitchFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-TwitchFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TwitchFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TwitchFill;

--- a/src/icons/twitter-fill.js
+++ b/src/icons/twitter-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TwitterFill = ({
   color = 'currentColor',
@@ -20,9 +19,13 @@ const TwitterFill = ({
   );
 };
 
-TwitterFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TwitterFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TwitterFill;

--- a/src/icons/two-line-horizontal.js
+++ b/src/icons/two-line-horizontal.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TwoLineHorizontal = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TwoLineHorizontal = ({
   );
 };
 
-TwoLineHorizontal.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TwoLineHorizontal.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TwoLineHorizontal;

--- a/src/icons/two-line-vertical.js
+++ b/src/icons/two-line-vertical.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TwoLineVertical = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const TwoLineVertical = ({
   );
 };
 
-TwoLineVertical.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TwoLineVertical.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TwoLineVertical;

--- a/src/icons/typescript-fill.js
+++ b/src/icons/typescript-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const TypescriptFill = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const TypescriptFill = ({
   );
 };
 
-TypescriptFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  TypescriptFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default TypescriptFill;

--- a/src/icons/umbrella.js
+++ b/src/icons/umbrella.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Umbrella = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Umbrella = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Umbrella.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Umbrella.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Umbrella;

--- a/src/icons/unsplash-fill.js
+++ b/src/icons/unsplash-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const UnsplashFill = ({
   color = 'currentColor',
@@ -24,9 +23,13 @@ const UnsplashFill = ({
   );
 };
 
-UnsplashFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  UnsplashFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default UnsplashFill;

--- a/src/icons/utensils.js
+++ b/src/icons/utensils.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Utensils = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -25,9 +24,13 @@ const Utensils = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Utensils.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Utensils.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Utensils;

--- a/src/icons/vape-kit.js
+++ b/src/icons/vape-kit.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const VapeKit = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -26,9 +25,13 @@ const VapeKit = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-VapeKit.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  VapeKit.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default VapeKit;

--- a/src/icons/vercel-fill.js
+++ b/src/icons/vercel-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const VercelFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const VercelFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-VercelFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  VercelFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default VercelFill;

--- a/src/icons/victory-hand.js
+++ b/src/icons/victory-hand.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const VictoryHand = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const VictoryHand = ({
   );
 };
 
-VictoryHand.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  VictoryHand.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default VictoryHand;

--- a/src/icons/video.js
+++ b/src/icons/video.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Video = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const Video = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Video.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Video.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Video;

--- a/src/icons/vimeo-fill.js
+++ b/src/icons/vimeo-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const VimeoFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const VimeoFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-VimeoFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  VimeoFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default VimeoFill;

--- a/src/icons/vk-fill.js
+++ b/src/icons/vk-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const VkFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const VkFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-VkFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  VkFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default VkFill;

--- a/src/icons/vr-ar.js
+++ b/src/icons/vr-ar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const VrAr = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const VrAr = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-VrAr.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  VrAr.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default VrAr;

--- a/src/icons/vscode-fill.js
+++ b/src/icons/vscode-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const VscodeFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -26,9 +25,13 @@ const VscodeFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-VscodeFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  VscodeFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default VscodeFill;

--- a/src/icons/vue-fill.js
+++ b/src/icons/vue-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const VueFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const VueFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-VueFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  VueFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default VueFill;

--- a/src/icons/wallet.js
+++ b/src/icons/wallet.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Wallet = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Wallet = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Wallet.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Wallet.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Wallet;

--- a/src/icons/watch-device.js
+++ b/src/icons/watch-device.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const WatchDevice = ({
   color = 'currentColor',
@@ -26,9 +25,13 @@ const WatchDevice = ({
   );
 };
 
-WatchDevice.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  WatchDevice.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default WatchDevice;

--- a/src/icons/water.js
+++ b/src/icons/water.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Water = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Water = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Water.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Water.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Water;

--- a/src/icons/whatsapp-fill.js
+++ b/src/icons/whatsapp-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const WhatsappFill = ({
   color = 'currentColor',
@@ -31,9 +30,13 @@ const WhatsappFill = ({
   );
 };
 
-WhatsappFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  WhatsappFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default WhatsappFill;

--- a/src/icons/width.js
+++ b/src/icons/width.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Width = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const Width = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Width.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Width.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Width;

--- a/src/icons/wifi.js
+++ b/src/icons/wifi.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const Wifi = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -22,9 +21,13 @@ const Wifi = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-Wifi.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  Wifi.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default Wifi;

--- a/src/icons/wine-glass.js
+++ b/src/icons/wine-glass.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const WineGlass = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -23,9 +22,13 @@ const WineGlass = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-WineGlass.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  WineGlass.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default WineGlass;

--- a/src/icons/x-fill.js
+++ b/src/icons/x-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const XFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -16,9 +15,13 @@ const XFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-XFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  XFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default XFill;

--- a/src/icons/x-small.js
+++ b/src/icons/x-small.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const XSmall = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -20,9 +19,13 @@ const XSmall = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-XSmall.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  XSmall.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default XSmall;

--- a/src/icons/yarn-fill.js
+++ b/src/icons/yarn-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const YarnFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -28,9 +27,13 @@ const YarnFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-YarnFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  YarnFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default YarnFill;

--- a/src/icons/yelp-fill.js
+++ b/src/icons/yelp-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const YelpFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -40,9 +39,13 @@ const YelpFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-YelpFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  YelpFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default YelpFill;

--- a/src/icons/youtube-fill.js
+++ b/src/icons/youtube-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const YoutubeFill = ({
   color = 'currentColor',
@@ -27,9 +26,13 @@ const YoutubeFill = ({
   );
 };
 
-YoutubeFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  YoutubeFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default YoutubeFill;

--- a/src/icons/zoom-fill.js
+++ b/src/icons/zoom-fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ZoomFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -27,9 +26,13 @@ const ZoomFill = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ZoomFill.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ZoomFill.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ZoomFill;

--- a/src/icons/zoom-in.js
+++ b/src/icons/zoom-in.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ZoomIn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ZoomIn = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ZoomIn.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ZoomIn.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ZoomIn;

--- a/src/icons/zoom-out.js
+++ b/src/icons/zoom-out.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const ZoomOut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   return (
@@ -21,9 +20,13 @@ const ZoomOut = ({ color = 'currentColor', size = '24', ...otherProps }) => {
   );
 };
 
-ZoomOut.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
+if (process.env.NODE_ENV !== 'production') {
+  const PropTypes = require('prop-types');
+
+  ZoomOut.propTypes = {
+    color: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+}
 
 export default ZoomOut;


### PR DESCRIPTION
## Summary
- add an ESM package entry at `dist/esm/icons.js`
- emit preserved ESM modules for each icon so bundlers can drop unused icons
- keep the existing CommonJS `dist/index.js` entry for legacy `require('akar-icons')` consumers
- mark the package as side-effect free

## Verification
- `npm run build:bundle`
- packed the package and bundled a consumer importing only `{ ArrowRight }` with Rollup + node-resolve
- verified the generated consumer bundle is 2,243 bytes, contains `ArrowRight`, and does not contain `ArrowLeft`, `YoutubeFill`, or the CommonJS all-icons wrapper
- verified `require('akar-icons').ArrowRight` and `require('akar-icons').ArrowLeft` still resolve to functions